### PR TITLE
Refactor preview generation to be client-side

### DIFF
--- a/web/src/components/JournalApp.tsx
+++ b/web/src/components/JournalApp.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import { useState, useEffect } from 'react';
-import { useAccount, useWriteContract, useReadContract } from 'wagmi';
+import { useAccount, useWriteContract } from 'wagmi';
 import { bob } from '@/lib/chains';
 import { contractAddress, contractAbi } from '@/lib/contract';
 import { ConnectButton } from '@rainbow-me/rainbowkit';
@@ -24,12 +24,47 @@ const EMOJIS = [
   { e: '😏', t: 'Smirk' },
 ];
 
+const escapeHTML = (str: string) => {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};
+
+const generateSVG = (text: string, mood: string) => {
+  const escapedText = escapeHTML(text);
+  const escapedMood = escapeHTML(mood);
+  const timestamp = Math.floor(Date.now() / 1000);
+
+  // Note: The SVG structure is intentionally similar to the one in the smart contract.
+  return `<svg width="500" height="500" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+          <stop offset="0%" style="stop-color:#f25d00;stop-opacity:1" />
+          <stop offset="100%" style="stop-color:#c026d3;stop-opacity:1" />
+        </linearGradient>
+      </defs>
+      <rect width="100%" height="100%" rx="20" ry="20" fill="url(#grad)"/>
+      <rect x="8" y="8" width="484" height="484" rx="15" ry="15" fill="#f25d00"/>
+      <text x="450" y="90" font-family="sans-serif" font-size="70" text-anchor="end" fill="white">${escapedMood}</text>
+      <text x="50" y="75" font-family="monospace" font-size="20" fill="white" fill-opacity="0.8">Timestamp: ${timestamp}</text>
+      <foreignObject x="50" y="120" width="400" height="280">
+        <div xmlns="http://www.w3.org/1999/xhtml" style="color: white; font-family: sans-serif; font-size: 22px; word-wrap: break-word; line-height: 1.5;">
+          ${escapedText}
+        </div>
+      </foreignObject>
+      <text x="50" y="450" font-family="monospace" font-size="16" fill="white" fill-opacity="0.5">On-Chain Journal</text>
+    </svg>`;
+};
+
 export default function JournalApp() {
   const [mood, setMood] = useState(EMOJIS[0].e);
   const [text, setText] = useState('');
 
   // Wagmi hooks for wallet connection and network switching
-  const { address, isConnected, chainId } = useAccount();
+  const { isConnected, chainId } = useAccount();
 
   // Check if the user is on the correct network (BOB)
   const onBob = chainId === bob.id;
@@ -37,25 +72,6 @@ export default function JournalApp() {
 
   // Wagmi hook for writing to the contract
   const { data: hash, isPending, isSuccess, isError, writeContract } = useWriteContract();
-
-  // Wagmi hook for reading from the contract to generate the preview
-  const { data: svg, isLoading: isPreviewLoading } = useReadContract({
-    address: contractAddress,
-    abi: contractAbi,
-    functionName: 'generateSVG',
-    args: [
-      {
-        text: text || ' ', // Pass a space if text is empty, as contract may not handle empty strings.
-        mood: mood,
-        timestamp: BigInt(Math.floor(Date.now() / 1000)),
-        owner: address || '0x0000000000000000000000000000000000000000',
-      },
-    ],
-    query: {
-      // Only run the query if the form is enabled (wallet connected to BOB)
-      enabled: isFormEnabled,
-    },
-  });
 
   useEffect(() => {
     if (isSuccess) {
@@ -181,10 +197,11 @@ export default function JournalApp() {
       <div className="flex flex-col items-center">
         <h2 className="text-2xl font-bold mb-4">Live NFT Preview</h2>
         <div className="w-full max-w-[500px] aspect-square bg-gray-700 border-2 border-gray-600 rounded-lg overflow-hidden flex items-center justify-center">
-          {isPreviewLoading && isFormEnabled && <div>Generating preview...</div>}
-          {svg && isFormEnabled ? (
+          {isFormEnabled ? (
             <img
-              src={`data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svg)))}`}
+              src={`data:image/svg+xml;base64,${btoa(
+                unescape(encodeURIComponent(generateSVG(text, mood))),
+              )}`}
               alt="NFT Preview"
             />
           ) : (


### PR DESCRIPTION
Refactor preview generation to be client-side

The previous implementation of the NFT preview used a `useReadContract` hook to generate the SVG on-chain for every change. This caused a noticeable delay and a "green screen" flash while the new preview was being fetched.

I have refactored the preview generation to be entirely client-side, replicating the SVG generation logic from the smart contract in a JavaScript function within the `JournalApp` component.

- Re-implemented `generateSVG` and `escapeHTML` functions in `JournalApp.tsx`.
- Removed the `useReadContract` hook for preview generation, eliminating the network round-trip.
- The preview now updates instantaneously as you type, providing a smooth experience.
- Fixed a linting error where the `address` variable was unused after the refactor.