### PR TITLE
Display the latest mints

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -24,3 +24,56 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+.latest-mints-container {
+  width: 100%;
+  max-width: 6xl;
+  margin: 0 auto;
+  padding: 1rem;
+  color: white;
+}
+
+.latest-mints-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: #1f2937;
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+.toggle-button {
+  background-color: #f97316;
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  border: none;
+  cursor: pointer;
+}
+
+.latest-mints-gallery {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  background-color: #374151;
+  border-radius: 0.5rem;
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+
+.mint-item {
+  display: block;
+  border: 2px solid transparent;
+  border-radius: 0.5rem;
+  transition: border-color 0.2s;
+}
+
+.mint-item:hover {
+  border-color: #f97316;
+}
+
+.mint-image {
+  width: 100px;
+  height: 100px;
+  border-radius: 0.5rem;
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import JournalApp from '@/components/JournalApp';
 import Footer from '@/components/Footer';
+import LatestMints from '@/components/LatestMints';
 
 export default function Home() {
   return (
@@ -7,6 +8,7 @@ export default function Home() {
       <main className="min-h-screen flex flex-col items-center justify-center p-4">
         <JournalApp />
       </main>
+      <LatestMints />
       <Footer />
     </>
   );

--- a/web/src/components/LatestMints.tsx
+++ b/web/src/components/LatestMints.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { usePublicClient } from 'wagmi';
+import { contractAddress, contractAbi } from '@/lib/contract';
+import { bob } from '@/lib/chains';
+import { parseAbiItem } from 'viem';
+
+// Define the type for a mint event
+interface MintEvent {
+  minter: `0x${string}`;
+  tokenId: number;
+  imageUrl: string;
+}
+
+// Function to truncate an address for display
+const truncateAddress = (address: string) => {
+  return `${address.slice(0, 6)}...${address.slice(-4)}`;
+};
+
+export default function LatestMints() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [mints, setMints] = useState<MintEvent[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Get the public client from wagmi
+  const publicClient = usePublicClient({ chainId: bob.id });
+
+  useEffect(() => {
+    const fetchMints = async () => {
+      if (!publicClient) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+
+        // Fetch the Transfer events from the contract
+        const logs = await publicClient.getLogs({
+          address: contractAddress,
+          event: parseAbiItem('event Transfer(address indexed from, address indexed to, uint256 indexed tokenId)'),
+          args: {
+            from: '0x0000000000000000000000000000000000000000',
+          },
+          fromBlock: 'earliest',
+          toBlock: 'latest',
+        });
+
+        // Get the latest 5 mints
+        const latestLogs = logs.slice(-5).reverse();
+
+        const mintsData = await Promise.all(
+          latestLogs.map(async (log) => {
+            const { to: minter, tokenId } = log.args;
+
+            // Fetch the tokenURI to get the image
+            const tokenURI: any = await publicClient.readContract({
+                address: contractAddress,
+                abi: contractAbi,
+                functionName: 'tokenURI',
+                args: [tokenId],
+            });
+
+            // The tokenURI is a base64 encoded JSON string, so we need to decode it
+            const json = atob(tokenURI.substring(29)); // Remove "data:application/json;base64,"
+            const metadata = JSON.parse(json);
+            const imageUrl = metadata.image;
+
+            return {
+              minter: minter as `0x${string}`,
+              tokenId: Number(tokenId),
+              imageUrl: imageUrl,
+            };
+          })
+        );
+
+        setMints(mintsData);
+      } catch (error) {
+        console.error('Error fetching latest mints:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMints();
+  }, [publicClient]);
+
+  // If there are no mints, don't render the component
+  if (!isLoading && mints.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="latest-mints-container">
+      <div className="latest-mints-header">
+        {mints.length > 0 && (
+          <p>
+            {truncateAddress(mints[0].minter)} has minted token #{mints[0].tokenId}
+          </p>
+        )}
+        <button onClick={() => setIsOpen(!isOpen)} className="toggle-button">
+          {isOpen ? 'Hide' : 'Show'}
+        </button>
+      </div>
+      {isOpen && (
+        <div className="latest-mints-gallery">
+          {isLoading ? (
+            <p>Loading...</p>
+          ) : (
+            mints.map((mint) => (
+              <a
+                key={mint.tokenId}
+                href={`${bob.blockExplorers.default.url}/nft/${contractAddress}/${mint.tokenId}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mint-item"
+              >
+                <img src={mint.imageUrl} alt={`Token #${mint.tokenId}`} className="mint-image" />
+              </a>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/contract.ts
+++ b/web/src/lib/contract.ts
@@ -29,5 +29,30 @@ export const contractAbi = [
     "outputs": [{ "internalType": "string", "name": "", "type": "string" }],
     "stateMutability": "pure",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
   }
 ] as const;


### PR DESCRIPTION
… the OnChainJournal smart contract.

A new component, `LatestMints.tsx`, has been created to fetch and display the latest 5 mints. It shows the minter's address, the token ID, and a gallery of miniaturized NFT images. Each image links to the corresponding NFT on the Bob explorer.

The component is integrated into the main page, below the `JournalApp` and above the `Footer`.

The `Transfer` event has been added to the contract ABI to enable fetching mint events, and CSS has been added to style the new section.